### PR TITLE
add reveal by block

### DIFF
--- a/contract/contracts/SimpleToken.sol
+++ b/contract/contracts/SimpleToken.sol
@@ -15,14 +15,18 @@ contract SimpleToken is Ownable, ERC721, ERC721Enumerable, ReentrancyGuard {
     uint256 public maxSupply;
     uint256 public maxTokenAllow = 10;
     uint256 public price = 1000000000000000; 
+    uint256 public revealBlock = 0;
     uint256 public totalAirdropped = 0;
 
-    string public baseUrl;
     
-    constructor(string memory _name, string memory _symbol, uint256 _maxSupply, string memory _baseUrl) 
+    string public baseUrl;
+    string public defaultUrl;
+    
+    constructor(string memory _name, string memory _symbol, uint256 _maxSupply, string memory _baseUrl, string memory _defaultUrl) 
         ERC721(_name, _symbol)
     {
         baseUrl = _baseUrl;
+        defaultUrl = _defaultUrl;
         maxSupply = _maxSupply;
     }
 
@@ -57,10 +61,18 @@ contract SimpleToken is Ownable, ERC721, ERC721Enumerable, ReentrancyGuard {
         return true;
     }
 
+    function isRevealed() public view returns (bool) {
+        return revealBlock > 0 && block.number > revealBlock;
+    }
+
+    function setRevealBlock(uint256 blk) public onlyOwner {
+        revealBlock = blk;
+    }
+
     function tokenURI(uint256 tokenId) public view override (ERC721) returns (string memory) {
         require(tokenId < totalSupply(), "Token not exist.");
         
-        return string(abi.encodePacked(baseUrl, Strings.toString(tokenId), ".json"));        
+        return isRevealed() ? string(abi.encodePacked(baseUrl, Strings.toString(tokenId), ".json")) : defaultUrl;    
     }
 
     function _beforeTokenTransfer(address from, address to, uint256 tokenId

--- a/contract/scripts/deploy.js
+++ b/contract/scripts/deploy.js
@@ -1,0 +1,39 @@
+const { BigNumber } = require("ethers");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log("Deploying contracts with the account:", deployer.address);
+
+  const balanceBefore =  await deployer.getBalance();
+  console.log("Account balance:", balanceBefore.toString());
+
+  
+  const tokenName = "SimpleToken";
+  const tokenSymbol = "SPT";
+  const baseUri = "https://simpletoken.web.app/metadata/";
+  const defaultUri = "https://simpletoken.web.app/metadata/default.json";
+  const maxSupply = 1000;
+
+  const contract = await hre.ethers.getContractFactory("SimpleToken");
+  const token = await contract.deploy(tokenName, tokenSymbol, maxSupply, baseUri, defaultUri);
+
+  await token.deployed()
+
+  // generate verify command
+  console.log("Contract deployed to:", token.address);
+  console.log("Verify contract with following command");
+  console.log("\r\n BSC Testnet");
+  console.log(`npx hardhat verify --network bsctestnet "${tokenName}" "${tokenSymbol}" ${maxSupply} "${baseUri}" "${defaultUri}`);
+
+  const balanceAfter =  await deployer.getBalance();
+  const gasUsed = balanceBefore - balanceAfter;
+
+  console.log(`Fee used: ${gasUsed}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/contract/tests/test.js
+++ b/contract/tests/test.js
@@ -10,7 +10,8 @@ describe("SimpleToken tests", function () {
             "Test Token",
             "TST",
             1000,
-            "http://someurl.com/metadata/"
+            "http://someurl.com/metadata/",
+            "http://someurl.com/default.json"
         );
 
         await token.deployed();
@@ -141,9 +142,15 @@ describe("SimpleToken tests", function () {
         expect(BigNumber.from("10")._hex).to.equal(balance._hex);
     
         let metadata = await token.tokenURI(1);
-        expect(metadata).to.equal("http://someurl.com/metadata/1.json");
+        expect(metadata).to.equal("http://someurl.com/default.json");
+
+        await token.setRevealBlock(1);
+        await ethers.provider.send('evm_mine');
 
         metadata = await token.tokenURI(2);
         expect(metadata).to.equal("http://someurl.com/metadata/2.json");
+
+        metadata = await token.tokenURI(3);
+        expect(metadata).to.equal("http://someurl.com/metadata/3.json");
       });
 });

--- a/contract/tests/test.js
+++ b/contract/tests/test.js
@@ -126,7 +126,7 @@ describe("SimpleToken tests", function () {
         expect(BigNumber.from(total)._hex).to.equal(BigNumber.from("10")._hex);
       });
 
-      it("URI should be valid", async function () {    
+      it("URI should be reveal by block", async function () {    
         const [owner] = await ethers.getSigners();
     
         let error = null


### PR DESCRIPTION
Add reveal by block with test
Hardhat test:
```
npx hardhat test                                                                                                                                                                                                                                                                                                      

  SimpleToken tests
    ✓ Should return the right name and symbol
    ✓ Deployment should NOT assign any of tokens to the owner
    ✓ Airdrop Should transfer tokens to addresses (2 each) (49ms)
    ✓ Minting should fail when insufficient fund (57ms)
    ✓ Minting should success when NOT exceed limit (66ms)
    ✓ Minting should fail when exceed limit (71ms)
    ✓ URI should be reveal by block (70ms)


  7 passing (2s)

```
Deployment test:
```
npx hardhat run --network hardhat scripts/deploy.js                                                                                                                                                                                                                                                                   

Deploying contracts with the account: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
Account balance: 10000000000000000000000
Contract deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
Verify contract with following command

 BSC Testnet
npx hardhat verify --network bsctestnet "SimpleToken" "SPT" 1000 "https://simpletoken.web.app/metadata/" "https://simpletoken.web.app/metadata/default.json
Fee used: 4331793750687744```